### PR TITLE
add reading in of a input file file

### DIFF
--- a/b2handle-migration/migrationtool.py
+++ b/b2handle-migration/migrationtool.py
@@ -69,6 +69,8 @@ class MigrationTool(object):
         try:
             File = open(self.input_batch_filename,"r")
             for line in File:
+                line = line.replace("\n","")
+                line = line.replace("\r","")
                 self.all_handles.append(line)
             self.total_number_of_handles = len(self.all_handles)
         finally:


### PR DESCRIPTION
* first retrieve all handles using a mysql query.
* than split the file in to parts.
* fire of each migration tool with each input file.

This way you can start multiple migrations on one prefix. For 10 million  prefixes it will be shorter than 6 days if you parallelise it this way.